### PR TITLE
Allow `me` and `module` to be JavaScript files

### DIFF
--- a/api/lib/routes/me.js
+++ b/api/lib/routes/me.js
@@ -1,9 +1,12 @@
 var fs = require('fs');
+var path = require('path');
 var express = require('express');
 var router = express.Router();
 
-var me = JSON.parse(fs.readFileSync('me.json', 'utf8'));
-var modules = JSON.parse(fs.readFileSync('modules.json', 'utf8'));
+var cwd = process.cwd();
+
+var me = require(path.join(cwd, './me'));
+var modules = require(path.join(cwd, './modules'));
 
 var Me = function(me, modules) {
 	this.router = express.Router();
@@ -27,7 +30,7 @@ var Me = function(me, modules) {
 				this.router.post(endpoint, route.handler.bind(data));
 			}
 		}
-	}
+	};
 	this.router.get('/', function(req, res) {
 		res.json({ me: me, routes: this.routes });
 	}.bind(this));


### PR DESCRIPTION
This enables configuring middlewares programmatically, like so:

``` js
// ...
twitter: {
    data: {
      me: "frxbr",
      secrets: {
        "access_token": process.env.TWITTER_ACCESS_TOKEN,
        "consumer_key": process.env.TWITTER_CONSUMER_KEY,
        "consumer_secret": process.env.TWITTER_CONSUMER_SECRET,
        "access_token_secret": process.env.TWITTER_ACCESS_TOKEN_SECRET
    }
  },
  path: "/twitter"
}
// ...
```

Notice how keys/secrets are being loaded from the environment at runtime. 
