### PR TITLE
Change to Instagram middleware to return the photos that the user has posted, rather than the feed of the users they follow.

### DIFF
--- a/api/lib/middleware/instagram.js
+++ b/api/lib/middleware/instagram.js
@@ -18,7 +18,7 @@ var Instagram = {
 				if (!accessToken) return handleError("You have not specified an access Token yet", res);
 
 				ig.use(this.secrets);
-				ig.user_self_feed(function(err, media, pag) {
+				ig.user_self_media_recent(function(err, media, pag) {
 					if (err) return handleError(err, res);
 					var data = { photos: media };
 					cache.put('instagram', data, DEFAULT_CACHE_MSEC);


### PR DESCRIPTION
I realize this may be a philosophical difference, but when I query me.com/photos, I would expect to receive photos I have taken, rather than photos all of my Instagram friends have taken :)

Feel free to pull this in if you agree, however if you envision the Instagram middleware to do otherwise, then so be it.
